### PR TITLE
Nouvelle recette: Marteau de Thor

### DIFF
--- a/src/recipes/index.ts
+++ b/src/recipes/index.ts
@@ -2,12 +2,12 @@ import { Recipe } from '@/types/recipe';
 import { poutineClassique } from './poutine-classique';
 import { tourtiereLacSaintJean } from './tourtiere-lac-saint-jean';
 import { tarteAuSucre } from './tarte-au-sucre';
+import { marteaudethorRecipe } from './marteau-de-thor';
 
-export const recipes: Recipe[] = [
-  poutineClassique,
+export const recipes: Recipe[] = [poutineClassique,
   tourtiereLacSaintJean,
-  tarteAuSucre
-];
+  tarteAuSucre,
+  marteaudethorRecipe];
 
 // Helper function to get a recipe by slug
 export const getRecipeBySlug = (slug: string): Recipe | undefined => {

--- a/src/recipes/marteau-de-thor.ts
+++ b/src/recipes/marteau-de-thor.ts
@@ -1,0 +1,25 @@
+import { Recipe } from '@/types/recipe';
+
+export const marteaudethorRecipe: Recipe = {
+  id: '1757465658768',
+  title: 'Marteau de Thor',
+  description: 'Impressionnez vos invités avec cette spectaculaire recette de jarret de boeuf',
+  category: 'Fumoir',
+  prepTime: 20,
+  cookTime: 720,
+  marinatingTime: 480,
+  servings: 12,
+  difficulty: 'Moyen',
+  ingredients: [
+
+  ],
+  instructions: [
+
+  ],
+  tags: [],
+  image: '/images/marteau-de-thor.jpg',
+  accompaniment: 'Saucisses fumées',
+  wine: 'Baron de Ley, reserva',
+  source: 'David Cloutier',
+  slug: 'marteau-de-thor'
+};


### PR DESCRIPTION
## Nouvelle recette ajoutée

**Titre:** Marteau de Thor
**Catégorie:** Fumoir
**Difficulté:** Moyen
**Temps total:** 740 minutes
**Temps de marinage:** 480 minutes
**Portions:** 12
**Accompagnement:** Saucisses fumées
**Accord vin:** Baron de Ley, reserva

**Description:**
Impressionnez vos invités avec cette spectaculaire recette de jarret de boeuf

**Tags:** 

---
*Cette recette a été ajoutée via le formulaire web.*