### PR TITLE
Modification recette: Poutine Classique

### DIFF
--- a/src/recipes/poutine-classique.ts
+++ b/src/recipes/poutine-classique.ts
@@ -26,13 +26,7 @@ export const poutineClassique: Recipe = {
     'Servir immédiatement.'
   ],
   tags: ['Légumes'],
-  images: [
-    {
-      small: '/images/poutine-classique-small.jpg',
-      medium: '/images/poutine-classique-medium.jpg',
-      large: '/images/poutine-classique-large.jpg'
-    }
-  ],
   source: 'David Cloutier',
+  notes: 'Vous pouvez faire cuire les frites au four à 425°F si vous préférez',
   slug: 'poutine-classique'
 };


### PR DESCRIPTION
## Recette modifiée

**Titre:** Poutine Classique
**Catégorie:** Plats principaux
**Difficulté:** Facile
**Temps total:** 45 minutes
**Portions:** 4
**Source:** David Cloutier
**Notes:** Vous pouvez faire cuire les frites au four à 425°F si vous préférez

**Description:**
La poutine traditionnelle du Québec avec frites, fromage en grains et sauce brune.

**Tags:** Légumes

---
*Cette recette a été modifiée via le formulaire web.*