### PR TITLE
Modification recette: Poutine Classique

### DIFF
--- a/src/recipes/poutine-classique.ts
+++ b/src/recipes/poutine-classique.ts
@@ -26,13 +26,6 @@ export const poutineClassique: Recipe = {
     'Servir immédiatement.'
   ],
   tags: ['traditionnel', 'frites', 'fromage'],
-  images: [
-    {
-      small: 'https://res.cloudinary.com/nosrecettes/image/upload/w_400,h_300,c_fill,q_auto,f_auto/recipes/poutine',
-      medium: 'https://res.cloudinary.com/nosrecettes/image/upload/w_800,h_600,c_fill,q_auto,f_auto/recipes/poutine',
-      large: 'https://res.cloudinary.com/nosrecettes/image/upload/w_1200,h_900,c_fill,q_auto,f_auto/recipes/poutine'
-    }
-  ],
   source: 'David Cloutier',
   notes: 'Vous pouvez faire cuire les frites au four à 425°F si vous préférez',
   slug: 'poutine-classique'


### PR DESCRIPTION
## Recette modifiée

**Titre:** Poutine Classique
**Catégories:** Plats principaux
**Difficulté:** Facile
**Temps total:** 45 minutes
**Portions:** 4
**Source:** David Cloutier
**Notes:** Vous pouvez faire cuire les frites au four à 425°F si vous préférez

**Description:**
La poutine traditionnelle du Québec avec frites, fromage en grains et sauce brune.

**Tags:** traditionnel, frites, fromage

---
*Cette recette a été modifiée via le formulaire web avec images hébergées sur Cloudinary.*