### PR TITLE
Modification recette: Sucre à la crème au Caramilk

### DIFF
--- a/src/recipes/sucre-a-la-creme-au-caramilk.ts
+++ b/src/recipes/sucre-a-la-creme-au-caramilk.ts
@@ -11,7 +11,7 @@ export const sucreALaCremeAuCaramilk: Recipe = {
   servings: 40,
   difficulty: 'Facile',
   ingredients: [
-    '1 tasse cassonade',
+    '2 tasse cassonade',
     '1 boîte lait Eagle Brand',
     '1/2 lb beurre',
     'vanille au goût',


### PR DESCRIPTION
## Recette modifiée

**Titre:** Sucre à la crème au Caramilk
**Catégories:** Pâtisseries et desserts
**Difficulté:** Facile
**Temps total:** 55 minutes
**Temps de marinage:** 30min (30-30 minutes)
**Portions:** 40
**Source:** David Cloutier
**Images:** 1 image(s) existante(s) conservée(s)

**Description:**


**Tags:** caramilk, micro-ondes, dessert

---
*Cette recette a été modifiée via le formulaire web avec gestion intelligente des images.*
*L'index des recettes sera mis à jour automatiquement lors du prochain déploiement.*