### PR TITLE
fix: add manifest/icon tags to prerendered recipe pages

### DIFF
--- a/scripts/build-ssg.ts
+++ b/scripts/build-ssg.ts
@@ -83,6 +83,24 @@ function assembleHtml(
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <!-- Favicon and Icons -->
+    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+    <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#0f172a" />
+    <meta name="msapplication-TileColor" content="#0f172a" />
+    <meta name="msapplication-config" content="/browserconfig.xml" />
+
+    <!-- Web App Manifest -->
+    <link rel="manifest" href="/manifest.json" />
+    <meta name="theme-color" content="#0f172a" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="apple-mobile-web-app-title" content="Nos Recettes" />
+    <meta name="mobile-web-app-capable" content="yes" />
+
     ${helmet.title.toString()}
     ${helmet.meta.toString()}
     ${helmet.link.toString()}


### PR DESCRIPTION
## Problem
The site stopped offering the \"Install app\" prompt on Android.

## Root cause
\`scripts/build-ssg.ts\` builds each prerendered \`/recipe/<slug>/index.html\` page's \`<head>\` solely from react-helmet's title/meta/link/script tags. It never carried over the static PWA tags that exist in the root \`index.html\` template (\`<link rel=\"manifest\">\`, favicon links, \`theme-color\`, \`apple-mobile-web-app-*\`).

Since recipe detail pages are the most common entry point (search results, shared links) and there are 721 of them, most visits landed on a page with **no manifest link at all**, failing Chrome's Android installability criteria — even though the homepage (\`dist/index.html\`, built normally by Vite) was fine.

## Fix
Added the same static manifest/icon/theme-color tags to the SSG head template in \`assembleHtml()\` so every prerendered recipe page also exposes the web app manifest.

## Verification
- Ran \`pnpm build\` (721 recipe pages rendered successfully)
- Confirmed \`dist/recipe/ailes-de-poulet/index.html\` now contains \`<link rel=\"manifest\" href=\"/manifest.json\" />\`