### PR TITLE
feat: copy ingredients/instructions to clipboard

### DIFF
--- a/src/components/RecipeDetail.tsx
+++ b/src/components/RecipeDetail.tsx
@@ -5,6 +5,7 @@ import {
   ChevronLeft,
   ChevronRight,
   Clock,
+  Copy,
   Edit,
   Share2,
   StickyNote,
@@ -24,6 +25,10 @@ import type {
   InstructionSection,
   Recipe,
 } from '@/types/recipe'
+import {
+  formatIngredientsForClipboard,
+  formatInstructionsForClipboard,
+} from '@/utils/clipboardFormat'
 import { getRecipeCategories } from '@/utils/recipeUtils'
 import { formatTime } from '@/utils/timeFormat'
 import { getMaxTime } from '@/utils/timeUtils'
@@ -93,6 +98,39 @@ export const RecipeDetail = ({
         })
       }
     }
+  }
+
+  const copyToClipboard = async (
+    text: string,
+    successTitle: string,
+    successDescription: string,
+  ): Promise<void> => {
+    try {
+      await navigator.clipboard.writeText(text)
+      toast({ title: successTitle, description: successDescription })
+    } catch {
+      toast({
+        title: 'Erreur',
+        description: 'Impossible de copier dans le presse-papier',
+        variant: 'destructive',
+      })
+    }
+  }
+
+  const handleCopyIngredients = (): void => {
+    void copyToClipboard(
+      formatIngredientsForClipboard(recipe.ingredients),
+      'Ingrédients copiés',
+      'Les ingrédients ont été copiés dans le presse-papier',
+    )
+  }
+
+  const handleCopyInstructions = (): void => {
+    void copyToClipboard(
+      formatInstructionsForClipboard(recipe.instructions),
+      'Instructions copiées',
+      'Les instructions ont été copiées dans le presse-papier',
+    )
   }
 
   // Helper function to render ingredients
@@ -347,15 +385,37 @@ export const RecipeDetail = ({
 
       <div className="grid md:grid-cols-2 gap-8">
         <Card>
-          <CardHeader>
+          <CardHeader className="flex flex-row items-center justify-between gap-2 space-y-0">
             <CardTitle>Ingrédients</CardTitle>
+            {recipe.ingredients.length > 0 && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleCopyIngredients}
+                data-testid="copy-ingredients-button"
+              >
+                <Copy className="w-4 h-4 mr-2" />
+                Copier
+              </Button>
+            )}
           </CardHeader>
           <CardContent>{renderIngredients()}</CardContent>
         </Card>
 
         <Card>
-          <CardHeader>
+          <CardHeader className="flex flex-row items-center justify-between gap-2 space-y-0">
             <CardTitle>Instructions</CardTitle>
+            {recipe.instructions.length > 0 && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleCopyInstructions}
+                data-testid="copy-instructions-button"
+              >
+                <Copy className="w-4 h-4 mr-2" />
+                Copier
+              </Button>
+            )}
           </CardHeader>
           <CardContent>{renderInstructions()}</CardContent>
         </Card>

--- a/src/utils/clipboardFormat.ts
+++ b/src/utils/clipboardFormat.ts
@@ -1,0 +1,62 @@
+import type { IngredientSection, InstructionSection } from '@/types/recipe'
+
+function isSectionedIngredients(
+  ingredients: string[] | IngredientSection[],
+): ingredients is IngredientSection[] {
+  return (
+    ingredients.length > 0 &&
+    typeof ingredients[0] === 'object' &&
+    'title' in ingredients[0]
+  )
+}
+
+function isSectionedInstructions(
+  instructions: string[] | InstructionSection[],
+): instructions is InstructionSection[] {
+  return (
+    instructions.length > 0 &&
+    typeof instructions[0] === 'object' &&
+    'title' in instructions[0]
+  )
+}
+
+/**
+ * Formats a recipe's ingredients as plain text suitable for copying to the
+ * clipboard. Preserves section titles when the ingredients are sectioned.
+ */
+export function formatIngredientsForClipboard(
+  ingredients: string[] | IngredientSection[],
+): string {
+  if (!isSectionedIngredients(ingredients)) {
+    return ingredients.map((item) => `- ${item}`).join('\n')
+  }
+
+  return ingredients
+    .map((section) => {
+      const lines = section.items.map((item) => `- ${item}`).join('\n')
+      return section.title ? `${section.title}\n${lines}` : lines
+    })
+    .join('\n\n')
+}
+
+/**
+ * Formats a recipe's instructions as plain text suitable for copying to the
+ * clipboard. Preserves section titles when the instructions are sectioned,
+ * restarting step numbering for each section to match the on-screen display.
+ */
+export function formatInstructionsForClipboard(
+  instructions: string[] | InstructionSection[],
+): string {
+  if (!isSectionedInstructions(instructions)) {
+    return instructions.map((step, index) => `${index + 1}. ${step}`).join('\n')
+  }
+
+  return instructions
+    .map((section) => {
+      const lines = section.steps
+        .map((step, index) => `${index + 1}. ${step}`)
+        .join('\n')
+      return section.title ? `${section.title}\n${lines}` : lines
+    })
+    .join('\n\n')
+}

--- a/tests/recipe-viewing/03-copy-to-clipboard.spec.ts
+++ b/tests/recipe-viewing/03-copy-to-clipboard.spec.ts
@@ -1,5 +1,4 @@
-import fs from 'node:fs'
-import path from 'node:path'
+import type { Page } from '@playwright/test'
 import type { Recipe } from '../../src/types/recipe'
 import {
   formatIngredientsForClipboard,
@@ -13,12 +12,12 @@ import { expect, test } from '../fixtures/baseFixtures'
  * Tests the ability to copy a recipe's ingredients or instructions to the
  * clipboard, including recipes whose ingredients/instructions are split
  * into titled sections (section titles must be preserved in the copy).
+ *
+ * Recipe data is fetched from the running app server (rather than read from
+ * `public/recipes.json` directly) because that file is generated/gitignored
+ * and isn't present in a fresh CI checkout - fetching it mirrors what the
+ * app itself does and works in both dev and preview (CI) modes.
  */
-
-const recipesData: { recipes: Recipe[] } = JSON.parse(
-  fs.readFileSync(path.join(process.cwd(), 'public', 'recipes.json'), 'utf-8'),
-)
-const recipes = recipesData.recipes
 
 function isSectioned(value: unknown[]): boolean {
   return (
@@ -29,20 +28,29 @@ function isSectioned(value: unknown[]): boolean {
   )
 }
 
-const flatRecipe = recipes.find(
-  (recipe) =>
-    !isSectioned(recipe.ingredients) && !isSectioned(recipe.instructions),
-)
+async function getTestRecipes(
+  page: Page,
+): Promise<{ flatRecipe: Recipe; sectionedRecipe: Recipe }> {
+  const response = await page.request.get('/recipes.json')
+  const data = (await response.json()) as { recipes: Recipe[] }
+  const recipes = data.recipes
 
-const sectionedRecipe = recipes.find(
-  (recipe) =>
-    isSectioned(recipe.ingredients) && isSectioned(recipe.instructions),
-)
-
-if (!flatRecipe || !sectionedRecipe) {
-  throw new Error(
-    'Test setup error: could not find both a flat and a sectioned recipe in public/recipes.json',
+  const flatRecipe = recipes.find(
+    (recipe) =>
+      !isSectioned(recipe.ingredients) && !isSectioned(recipe.instructions),
   )
+  const sectionedRecipe = recipes.find(
+    (recipe) =>
+      isSectioned(recipe.ingredients) && isSectioned(recipe.instructions),
+  )
+
+  if (!flatRecipe || !sectionedRecipe) {
+    throw new Error(
+      'Test setup error: could not find both a flat and a sectioned recipe in /recipes.json',
+    )
+  }
+
+  return { flatRecipe, sectionedRecipe }
 }
 
 test.describe('Copy to Clipboard', () => {
@@ -54,6 +62,7 @@ test.describe('Copy to Clipboard', () => {
     page,
     populatedDb,
   }) => {
+    const { flatRecipe } = await getTestRecipes(page)
     await page.goto(`/recipe/${flatRecipe.slug}`)
     await page.locator('h1').waitFor({ state: 'visible', timeout: 10000 })
 
@@ -71,6 +80,7 @@ test.describe('Copy to Clipboard', () => {
     page,
     populatedDb,
   }) => {
+    const { flatRecipe } = await getTestRecipes(page)
     await page.goto(`/recipe/${flatRecipe.slug}`)
     await page.locator('h1').waitFor({ state: 'visible', timeout: 10000 })
 
@@ -88,6 +98,7 @@ test.describe('Copy to Clipboard', () => {
     page,
     populatedDb,
   }) => {
+    const { sectionedRecipe } = await getTestRecipes(page)
     await page.goto(`/recipe/${sectionedRecipe.slug}`)
     await page.locator('h1').waitFor({ state: 'visible', timeout: 10000 })
 
@@ -115,6 +126,7 @@ test.describe('Copy to Clipboard', () => {
     page,
     populatedDb,
   }) => {
+    const { sectionedRecipe } = await getTestRecipes(page)
     await page.goto(`/recipe/${sectionedRecipe.slug}`)
     await page.locator('h1').waitFor({ state: 'visible', timeout: 10000 })
 
@@ -141,6 +153,7 @@ test.describe('Copy to Clipboard', () => {
     page,
     populatedDb,
   }) => {
+    const { flatRecipe } = await getTestRecipes(page)
     await page.goto(`/recipe/${flatRecipe.slug}`)
     await page.locator('h1').waitFor({ state: 'visible', timeout: 10000 })
 

--- a/tests/recipe-viewing/03-copy-to-clipboard.spec.ts
+++ b/tests/recipe-viewing/03-copy-to-clipboard.spec.ts
@@ -1,0 +1,151 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import type { Recipe } from '../../src/types/recipe'
+import {
+  formatIngredientsForClipboard,
+  formatInstructionsForClipboard,
+} from '../../src/utils/clipboardFormat'
+import { expect, test } from '../fixtures/baseFixtures'
+
+/**
+ * Test Suite: Copy Ingredients/Instructions to Clipboard
+ *
+ * Tests the ability to copy a recipe's ingredients or instructions to the
+ * clipboard, including recipes whose ingredients/instructions are split
+ * into titled sections (section titles must be preserved in the copy).
+ */
+
+const recipesData: { recipes: Recipe[] } = JSON.parse(
+  fs.readFileSync(path.join(process.cwd(), 'public', 'recipes.json'), 'utf-8'),
+)
+const recipes = recipesData.recipes
+
+function isSectioned(value: unknown[]): boolean {
+  return (
+    value.length > 0 &&
+    typeof value[0] === 'object' &&
+    value[0] !== null &&
+    'title' in value[0]
+  )
+}
+
+const flatRecipe = recipes.find(
+  (recipe) =>
+    !isSectioned(recipe.ingredients) && !isSectioned(recipe.instructions),
+)
+
+const sectionedRecipe = recipes.find(
+  (recipe) =>
+    isSectioned(recipe.ingredients) && isSectioned(recipe.instructions),
+)
+
+if (!flatRecipe || !sectionedRecipe) {
+  throw new Error(
+    'Test setup error: could not find both a flat and a sectioned recipe in public/recipes.json',
+  )
+}
+
+test.describe('Copy to Clipboard', () => {
+  test.beforeEach(async ({ context }) => {
+    await context.grantPermissions(['clipboard-read', 'clipboard-write'])
+  })
+
+  test('should copy flat ingredients to clipboard preserving order', async ({
+    page,
+    populatedDb,
+  }) => {
+    await page.goto(`/recipe/${flatRecipe.slug}`)
+    await page.locator('h1').waitFor({ state: 'visible', timeout: 10000 })
+
+    await page.locator('[data-testid="copy-ingredients-button"]').click()
+
+    const clipboardText = await page.evaluate(() =>
+      navigator.clipboard.readText(),
+    )
+    expect(clipboardText).toBe(
+      formatIngredientsForClipboard(flatRecipe.ingredients),
+    )
+  })
+
+  test('should copy flat instructions to clipboard preserving order', async ({
+    page,
+    populatedDb,
+  }) => {
+    await page.goto(`/recipe/${flatRecipe.slug}`)
+    await page.locator('h1').waitFor({ state: 'visible', timeout: 10000 })
+
+    await page.locator('[data-testid="copy-instructions-button"]').click()
+
+    const clipboardText = await page.evaluate(() =>
+      navigator.clipboard.readText(),
+    )
+    expect(clipboardText).toBe(
+      formatInstructionsForClipboard(flatRecipe.instructions),
+    )
+  })
+
+  test('should preserve section titles when copying sectioned ingredients', async ({
+    page,
+    populatedDb,
+  }) => {
+    await page.goto(`/recipe/${sectionedRecipe.slug}`)
+    await page.locator('h1').waitFor({ state: 'visible', timeout: 10000 })
+
+    await page.locator('[data-testid="copy-ingredients-button"]').click()
+
+    const clipboardText = await page.evaluate(() =>
+      navigator.clipboard.readText(),
+    )
+    const expectedText = formatIngredientsForClipboard(
+      sectionedRecipe.ingredients,
+    )
+    expect(clipboardText).toBe(expectedText)
+
+    // Sanity check: every section title actually made it into the copy
+    for (const section of sectionedRecipe.ingredients as {
+      title: string
+    }[]) {
+      if (section.title) {
+        expect(clipboardText).toContain(section.title)
+      }
+    }
+  })
+
+  test('should preserve section titles when copying sectioned instructions', async ({
+    page,
+    populatedDb,
+  }) => {
+    await page.goto(`/recipe/${sectionedRecipe.slug}`)
+    await page.locator('h1').waitFor({ state: 'visible', timeout: 10000 })
+
+    await page.locator('[data-testid="copy-instructions-button"]').click()
+
+    const clipboardText = await page.evaluate(() =>
+      navigator.clipboard.readText(),
+    )
+    const expectedText = formatInstructionsForClipboard(
+      sectionedRecipe.instructions,
+    )
+    expect(clipboardText).toBe(expectedText)
+
+    for (const section of sectionedRecipe.instructions as {
+      title: string
+    }[]) {
+      if (section.title) {
+        expect(clipboardText).toContain(section.title)
+      }
+    }
+  })
+
+  test('should show a confirmation toast after copying', async ({
+    page,
+    populatedDb,
+  }) => {
+    await page.goto(`/recipe/${flatRecipe.slug}`)
+    await page.locator('h1').waitFor({ state: 'visible', timeout: 10000 })
+
+    await page.locator('[data-testid="copy-ingredients-button"]').click()
+
+    await expect(page.getByText('Ingrédients copiés')).toBeVisible()
+  })
+})


### PR DESCRIPTION
## Summary
Adds a "Copier" button to the Ingrédients and Instructions cards on the recipe detail page, letting users copy the list as plain text (e.g. to paste into a notes app or grocery list).

- Preserves section titles for recipes whose ingredients/instructions are split into sections (e.g. "Sauce", "Montage").
- Instruction numbering restarts per section to match what's shown on screen.
- Shows a success/error toast after copying.

## Changes
- `src/utils/clipboardFormat.ts`: pure formatting helpers (`formatIngredientsForClipboard`, `formatInstructionsForClipboard`) handling both flat and sectioned data.
- `src/components/RecipeDetail.tsx`: copy buttons wired to `navigator.clipboard.writeText`, with `data-testid="copy-ingredients-button"` / `data-testid="copy-instructions-button"`.
- `tests/recipe-viewing/03-copy-to-clipboard.spec.ts`: new E2E suite covering flat recipes, sectioned recipes (section titles preserved), and the confirmation toast, using real recipe data from `public/recipes.json`.

## Testing
- `npx playwright test tests/recipe-viewing` — 30/30 passed
- `rtk lint check` — no issues